### PR TITLE
Clustering is feature toggleable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ ws = new WebSocket('ws://localhost:8008/websockify/destInfoToken/68025b6c-2db5-4
 
 ### Development Mode
 
-To be able to debug, set an environment variable, so that **Websockify** does not use node cluster:
+To be able to debug, the service should not use node cluster, however this is disabled by default with an envar:
 
 ```bash
-export EYEOS_WEBSOCKIFY_USE_WITHOUT_CLUSTER=true
+export EYEOS_WEBSOCKIFY_USE_CLUSTER=false
 ```
 
 * Connect using an url in the client

--- a/netMeasurer/netMeasurer.js
+++ b/netMeasurer/netMeasurer.js
@@ -26,10 +26,13 @@ var settings = require("./settings");
 
 console.log("Creating websocket pong server at port ", settings.port);
 
-ws.createServer(function (conn) {
-    var notifier = new Notifier();
-    notifier.registerService(uuid.v4().split('-')[4], 'netMesurer', null, settings.port);
+var server = ws.createServer(function (conn) {
 	conn.on("text", function (str) {
 		conn.sendText("pong");
 	});
-}).listen(settings.port);
+});
+
+server.listen(settings.port, function() {
+    var notifier = new Notifier();
+    notifier.registerService(uuid.v4().split('-')[4], 'netMesurer', null, settings.port);
+});

--- a/src/eyeos-websockify.js
+++ b/src/eyeos-websockify.js
@@ -43,7 +43,8 @@ process.on('uncaughtException', function(err) {
 	logger.error(err.stack);
 });
 
-if (globalConfig.useWithoutCluster) {
+if (!globalConfig.useCluster) {
+    httpsServer.listen(globalConfig.source.port);
 	var websockifyServer = new Server(httpsServer, 0);
 	websockifyServer.start(false);
     var notifier = new Notifier();

--- a/src/libs/Server.js
+++ b/src/libs/Server.js
@@ -59,7 +59,7 @@ Server.prototype.start = function (isInCluster) {
 
 Server.prototype.onConnectionCallback = function(websocket, config) {
 	var self = this;
-	var isInCluster = !config.useWithoutCluster;
+	var isInCluster = config.useCluster;
 	if (isInCluster) {
 		var strSocket = '[' + (new Date()).getTime() + '][' + this.pid + '][' + websocket.remoteAddress + ':' + websocket.remotePort + ':' + config.target.port + '] ';
 	} else {

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -40,7 +40,7 @@ var config = {
 	// == Settings
 
 	protocol: process.env.EYEOS_WEBSOCKIFY_PROTOCOL || 'https',
-	useWithoutCluster: process.env.EYEOS_WEBSOCKIFY_USE_WITHOUT_CLUSTER === "true" || false,
+	useCluster: process.env.EYEOS_WEBSOCKIFY_USE_CLUSTER === "true" || false,
 
 	secretSharer: {
 		host: process.env.EYEOS_WEBSOCKIFY_REDIS_HOST || 'redis.service.consul',


### PR DESCRIPTION
Now that open365 targets multiple platforms, we need the flexibility to
perform optimally for each unique environment.  This could mean getting
more out of the CPU by launching multi-node processes in a large
environment with a lot of processing power or reducing to a single-
threaded process for smaller environments with minimal processing power.

For example, clustering should be enabled for production, but perhaps
disabled for users installing open365 in a raspberry pi.

Clustering can now be enabled/disabled with the envar
EYEOS_WEBSOCKIFY_USE_CLUSTER

· updated readme
· changed confusing double-negative variables:
EYEOS_WEBSOCKIFY_USE_WITHOUT_CLUSTER -> EYEOS_WEBSOCKIFY_USE_CLUSTER
useWithoutCluster -> useCluster
